### PR TITLE
UUID based links support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,8 @@ node_modules
 
 # Editors
 .idea
+
+# Webstorm compiled files
+src/vignette.js
+
+src/vignette.js.map

--- a/dist/vignette.amd.js
+++ b/dist/vignette.amd.js
@@ -243,7 +243,7 @@ define(["require", "exports"], function (require, exports) {
          *
          * @private
          *
-         * @param {String} url
+         * @param {String} currentUrl
          * @param {object} options
          *
          * @returns {String}
@@ -292,7 +292,7 @@ define(["require", "exports"], function (require, exports) {
         Vignette.imagePathRegExp = /\/\/vignette(\d|-poz)?\.wikia/;
         Vignette.domainRegExp = /(wikia-dev.com|wikia.nocookie.net)/;
         Vignette.legacyPathRegExp = /(wikia-dev.com|wikia.nocookie.net)\/__cb[\d]+\/.*$/;
-        Vignette.onlyUUIDRegExp = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/;
+        Vignette.onlyUUIDRegExp = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/i;
         Vignette.mode = {
             fixedAspectRatio: 'fixed-aspect-ratio',
             fixedAspectRatioDown: 'fixed-aspect-ratio-down',

--- a/dist/vignette.amd.js
+++ b/dist/vignette.amd.js
@@ -1,8 +1,8 @@
-/**
- * Helper module to generate the URL to a thumbnail of specific size from JS
- */
-'use strict';
 define(["require", "exports"], function (require, exports) {
+    /**
+     * Helper module to generate the URL to a thumbnail of specific size from JS
+     */
+    'use strict';
     var Vignette = (function () {
         function Vignette() {
         }
@@ -34,6 +34,9 @@ define(["require", "exports"], function (require, exports) {
                 urlParameters = this.getParametersFromLegacyUrl(url);
                 url = this.createThumbnailUrl(urlParameters, options);
             }
+            else if (this.isUUIDOnlyUrl(url)) {
+                url = this.createUUIDBasedThumbnailUrl(url, options);
+            }
             else if (this.isThumbnailerUrl(url)) {
                 // Accept Vignette URL in order to convert thumbnail to a different mode
                 url = this.updateThumbnailUrl(url, options);
@@ -55,11 +58,16 @@ define(["require", "exports"], function (require, exports) {
                 if (!options.hasOwnProperty('width')) {
                     throw new Error('Required parameter `width` not specified for method getThumbUrl');
                 }
-                if (!options.hasOwnProperty('height') && options.mode !== Vignette.mode.scaleToWidth && options.mode !== Vignette.mode.windowCrop) {
+                if (!options.hasOwnProperty('height') &&
+                    options.mode !== Vignette.mode.scaleToWidth &&
+                    options.mode !== Vignette.mode.windowCrop) {
                     throw new Error('Thumbnailer mode `' + options.mode + '` requires height');
                 }
                 if (options.mode === Vignette.mode.windowCrop || options.mode === Vignette.mode.windowCropFixed) {
-                    if (!options.hasOwnProperty('xOffset1') || !options.hasOwnProperty('yOffset1') || !options.hasOwnProperty('xOffset2') || !options.hasOwnProperty('yOffset2')) {
+                    if (!options.hasOwnProperty('xOffset1') ||
+                        !options.hasOwnProperty('yOffset1') ||
+                        !options.hasOwnProperty('xOffset2') ||
+                        !options.hasOwnProperty('yOffset2')) {
                         throw new Error('Thumbnailer mode `' + options.mode + '` requires x and y offsets');
                     }
                 }
@@ -77,6 +85,19 @@ define(["require", "exports"], function (require, exports) {
         Vignette.isThumbnailerUrl = function (url) {
             if (url === void 0) { url = ''; }
             return this.imagePathRegExp.test(url);
+        };
+        /**
+         * Checks if url points to new Vignette
+         *
+         * @private
+         *
+         * @param {String} url
+         *
+         * @return {Boolean}
+         */
+        Vignette.isUUIDOnlyUrl = function (url) {
+            if (url === void 0) { url = ''; }
+            return this.onlyUUIDRegExp.test(url);
         };
         /**
          * Checks if url points to legacy image URL
@@ -189,6 +210,34 @@ define(["require", "exports"], function (require, exports) {
             return url.join('/') + '?' + query.join('&');
         };
         /**
+         * Constructs complete thumbnailer url for UUID based links
+         *
+         * @private
+         *
+         * @param {string} baseUrl
+         * @param {object} options
+         *
+         * @return {String}
+         */
+        Vignette.createUUIDBasedThumbnailUrl = function (baseUrl, options) {
+            var query = [];
+            //If last char is '/' then remove it
+            if (baseUrl.charAt(baseUrl.length - 1) === '/') {
+                baseUrl = baseUrl.substring(0, baseUrl.length - 1);
+            }
+            var url = [baseUrl];
+            if (options) {
+                if (options.hasOwnProperty('mode')) {
+                    url.push(this.getModeParameters(options));
+                }
+                if (options.hasOwnProperty('frame')) {
+                    query.push('frame=' + ~~options.frame);
+                }
+            }
+            return url.join('/') + (query.length > 0 ? '?' : '') + query.join('&');
+        };
+        ;
+        /**
          * Updates a Vignette URL with the given options. May be used to strip all options
          * from a URL and return the full-size image, if no options are passed in.
          *
@@ -243,6 +292,7 @@ define(["require", "exports"], function (require, exports) {
         Vignette.imagePathRegExp = /\/\/vignette(\d|-poz)?\.wikia/;
         Vignette.domainRegExp = /(wikia-dev.com|wikia.nocookie.net)/;
         Vignette.legacyPathRegExp = /(wikia-dev.com|wikia.nocookie.net)\/__cb[\d]+\/.*$/;
+        Vignette.onlyUUIDRegExp = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/;
         Vignette.mode = {
             fixedAspectRatio: 'fixed-aspect-ratio',
             fixedAspectRatioDown: 'fixed-aspect-ratio-down',
@@ -263,7 +313,8 @@ define(["require", "exports"], function (require, exports) {
             }
             // @see http://stackoverflow.com/a/5573422
             var webP = new Image();
-            webP.src = 'data:image/webp;' + 'base64,UklGRjoAAABXRUJQVlA4IC4AAACyAgCdASoCAAIALmk0mk0iIiIiIgBoSygABc6WWgAA/veff/0PP8bA//LwYAAA';
+            webP.src = 'data:image/webp;' +
+                'base64,UklGRjoAAABXRUJQVlA4IC4AAACyAgCdASoCAAIALmk0mk0iIiIiIgBoSygABc6WWgAA/veff/0PP8bA//LwYAAA';
             webP.onload = webP.onerror = function () {
                 Vignette.hasWebPSupport = (webP.height === 2);
             };

--- a/dist/vignette.cjs.js
+++ b/dist/vignette.cjs.js
@@ -242,7 +242,7 @@ var Vignette = (function () {
      *
      * @private
      *
-     * @param {String} url
+     * @param {String} currentUrl
      * @param {object} options
      *
      * @returns {String}
@@ -291,7 +291,7 @@ var Vignette = (function () {
     Vignette.imagePathRegExp = /\/\/vignette(\d|-poz)?\.wikia/;
     Vignette.domainRegExp = /(wikia-dev.com|wikia.nocookie.net)/;
     Vignette.legacyPathRegExp = /(wikia-dev.com|wikia.nocookie.net)\/__cb[\d]+\/.*$/;
-    Vignette.onlyUUIDRegExp = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/;
+    Vignette.onlyUUIDRegExp = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/i;
     Vignette.mode = {
         fixedAspectRatio: 'fixed-aspect-ratio',
         fixedAspectRatioDown: 'fixed-aspect-ratio-down',

--- a/dist/vignette.js
+++ b/dist/vignette.js
@@ -188,7 +188,7 @@ var Vignette = (function () {
             'http://vignette.' + urlParameters.domain,
             urlParameters.wikiaBucket,
             urlParameters.imagePath,
-            'revision/latest'
+            'revision/latest',
         ], query = [
             'cb=' + urlParameters.cacheBuster
         ];
@@ -220,6 +220,10 @@ var Vignette = (function () {
      */
     Vignette.createUUIDBasedThumbnailUrl = function (baseUrl, options) {
         var query = [];
+        //If last char is '/' then remove it
+        if (baseUrl.charAt(baseUrl.length - 1) === '/') {
+            baseUrl = baseUrl.substring(0, baseUrl.length - 1);
+        }
         var url = [baseUrl];
         if (options) {
             if (options.hasOwnProperty('mode')) {
@@ -287,7 +291,7 @@ var Vignette = (function () {
     Vignette.imagePathRegExp = /\/\/vignette(\d|-poz)?\.wikia/;
     Vignette.domainRegExp = /(wikia-dev.com|wikia.nocookie.net)/;
     Vignette.legacyPathRegExp = /(wikia-dev.com|wikia.nocookie.net)\/__cb[\d]+\/.*$/;
-    Vignette.onlyUUIDRegExp = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+    Vignette.onlyUUIDRegExp = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/;
     Vignette.mode = {
         fixedAspectRatio: 'fixed-aspect-ratio',
         fixedAspectRatioDown: 'fixed-aspect-ratio-down',

--- a/dist/vignette.js
+++ b/dist/vignette.js
@@ -242,7 +242,7 @@ var Vignette = (function () {
      *
      * @private
      *
-     * @param {String} url
+     * @param {String} currentUrl
      * @param {object} options
      *
      * @returns {String}
@@ -291,7 +291,7 @@ var Vignette = (function () {
     Vignette.imagePathRegExp = /\/\/vignette(\d|-poz)?\.wikia/;
     Vignette.domainRegExp = /(wikia-dev.com|wikia.nocookie.net)/;
     Vignette.legacyPathRegExp = /(wikia-dev.com|wikia.nocookie.net)\/__cb[\d]+\/.*$/;
-    Vignette.onlyUUIDRegExp = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/;
+    Vignette.onlyUUIDRegExp = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/i;
     Vignette.mode = {
         fixedAspectRatio: 'fixed-aspect-ratio',
         fixedAspectRatioDown: 'fixed-aspect-ratio-down',

--- a/dist/vignette.js
+++ b/dist/vignette.js
@@ -33,6 +33,9 @@ var Vignette = (function () {
             urlParameters = this.getParametersFromLegacyUrl(url);
             url = this.createThumbnailUrl(urlParameters, options);
         }
+        else if (this.isUUIDOnlyUrl(url)) {
+            url = this.createUUIDBasedThumbnailUrl(url, options);
+        }
         else if (this.isThumbnailerUrl(url)) {
             // Accept Vignette URL in order to convert thumbnail to a different mode
             url = this.updateThumbnailUrl(url, options);
@@ -54,11 +57,16 @@ var Vignette = (function () {
             if (!options.hasOwnProperty('width')) {
                 throw new Error('Required parameter `width` not specified for method getThumbUrl');
             }
-            if (!options.hasOwnProperty('height') && options.mode !== Vignette.mode.scaleToWidth && options.mode !== Vignette.mode.windowCrop) {
+            if (!options.hasOwnProperty('height') &&
+                options.mode !== Vignette.mode.scaleToWidth &&
+                options.mode !== Vignette.mode.windowCrop) {
                 throw new Error('Thumbnailer mode `' + options.mode + '` requires height');
             }
             if (options.mode === Vignette.mode.windowCrop || options.mode === Vignette.mode.windowCropFixed) {
-                if (!options.hasOwnProperty('xOffset1') || !options.hasOwnProperty('yOffset1') || !options.hasOwnProperty('xOffset2') || !options.hasOwnProperty('yOffset2')) {
+                if (!options.hasOwnProperty('xOffset1') ||
+                    !options.hasOwnProperty('yOffset1') ||
+                    !options.hasOwnProperty('xOffset2') ||
+                    !options.hasOwnProperty('yOffset2')) {
                     throw new Error('Thumbnailer mode `' + options.mode + '` requires x and y offsets');
                 }
             }
@@ -76,6 +84,19 @@ var Vignette = (function () {
     Vignette.isThumbnailerUrl = function (url) {
         if (url === void 0) { url = ''; }
         return this.imagePathRegExp.test(url);
+    };
+    /**
+     * Checks if url points to new Vignette
+     *
+     * @private
+     *
+     * @param {String} url
+     *
+     * @return {Boolean}
+     */
+    Vignette.isUUIDOnlyUrl = function (url) {
+        if (url === void 0) { url = ''; }
+        return this.onlyUUIDRegExp.test(url);
     };
     /**
      * Checks if url points to legacy image URL
@@ -167,7 +188,7 @@ var Vignette = (function () {
             'http://vignette.' + urlParameters.domain,
             urlParameters.wikiaBucket,
             urlParameters.imagePath,
-            'revision/latest',
+            'revision/latest'
         ], query = [
             'cb=' + urlParameters.cacheBuster
         ];
@@ -187,6 +208,30 @@ var Vignette = (function () {
         }
         return url.join('/') + '?' + query.join('&');
     };
+    /**
+     * Constructs complete thumbnailer url for UUID based links
+     *
+     * @private
+     *
+     * @param {string} baseUrl
+     * @param {object} options
+     *
+     * @return {String}
+     */
+    Vignette.createUUIDBasedThumbnailUrl = function (baseUrl, options) {
+        var query = [];
+        var url = [baseUrl];
+        if (options) {
+            if (options.hasOwnProperty('mode')) {
+                url.push(this.getModeParameters(options));
+            }
+            if (options.hasOwnProperty('frame')) {
+                query.push('frame=' + ~~options.frame);
+            }
+        }
+        return url.join('/') + (query.length > 0 ? '?' : '') + query.join('&');
+    };
+    ;
     /**
      * Updates a Vignette URL with the given options. May be used to strip all options
      * from a URL and return the full-size image, if no options are passed in.
@@ -242,6 +287,7 @@ var Vignette = (function () {
     Vignette.imagePathRegExp = /\/\/vignette(\d|-poz)?\.wikia/;
     Vignette.domainRegExp = /(wikia-dev.com|wikia.nocookie.net)/;
     Vignette.legacyPathRegExp = /(wikia-dev.com|wikia.nocookie.net)\/__cb[\d]+\/.*$/;
+    Vignette.onlyUUIDRegExp = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
     Vignette.mode = {
         fixedAspectRatio: 'fixed-aspect-ratio',
         fixedAspectRatioDown: 'fixed-aspect-ratio-down',
@@ -262,7 +308,8 @@ var Vignette = (function () {
         }
         // @see http://stackoverflow.com/a/5573422
         var webP = new Image();
-        webP.src = 'data:image/webp;' + 'base64,UklGRjoAAABXRUJQVlA4IC4AAACyAgCdASoCAAIALmk0mk0iIiIiIgBoSygABc6WWgAA/veff/0PP8bA//LwYAAA';
+        webP.src = 'data:image/webp;' +
+            'base64,UklGRjoAAABXRUJQVlA4IC4AAACyAgCdASoCAAIALmk0mk0iIiIiIgBoSygABc6WWgAA/veff/0PP8bA//LwYAAA';
         webP.onload = webP.onerror = function () {
             Vignette.hasWebPSupport = (webP.height === 2);
         };

--- a/src/vignette.ts
+++ b/src/vignette.ts
@@ -26,7 +26,7 @@ class Vignette {
 	private static imagePathRegExp: RegExp = /\/\/vignette(\d|-poz)?\.wikia/;
 	private static domainRegExp: RegExp = /(wikia-dev.com|wikia.nocookie.net)/;
 	private static legacyPathRegExp: RegExp = /(wikia-dev.com|wikia.nocookie.net)\/__cb[\d]+\/.*$/;
-	private static onlyUUIDRegExp: RegExp = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/;
+	private static onlyUUIDRegExp: RegExp = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/i;
 
 	public static mode: any = {
 		fixedAspectRatio: 'fixed-aspect-ratio',
@@ -328,7 +328,7 @@ class Vignette {
 	 *
 	 * @private
 	 *
-	 * @param {String} url
+	 * @param {String} currentUrl
 	 * @param {object} options
 	 *
 	 * @returns {String}

--- a/src/vignette.ts
+++ b/src/vignette.ts
@@ -26,7 +26,7 @@ class Vignette {
 	private static imagePathRegExp: RegExp = /\/\/vignette(\d|-poz)?\.wikia/;
 	private static domainRegExp: RegExp = /(wikia-dev.com|wikia.nocookie.net)/;
 	private static legacyPathRegExp: RegExp = /(wikia-dev.com|wikia.nocookie.net)\/__cb[\d]+\/.*$/;
-	private static onlyUUIDRegExp: RegExp = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+	private static onlyUUIDRegExp: RegExp = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/;
 
 	public static mode: any = {
 		fixedAspectRatio: 'fixed-aspect-ratio',
@@ -159,7 +159,7 @@ class Vignette {
 	 */
 	private static isUUIDOnlyUrl(url = ''): boolean {
 		return this.onlyUUIDRegExp.test(url);
-	};
+	}
 
 	/**
 	 * Checks if url points to legacy image URL
@@ -303,6 +303,12 @@ class Vignette {
 		options: ThumbnailOptions
 	): string {
 		var query = [];
+
+		//If last char is '/' then remove it
+		if(baseUrl.charAt(baseUrl.length - 1) === '/') {
+			baseUrl = baseUrl.substring(0, baseUrl.length - 1);
+		}
+
 		var url = [baseUrl];
 
 		if (options) {

--- a/src/vignette.ts
+++ b/src/vignette.ts
@@ -26,6 +26,7 @@ class Vignette {
 	private static imagePathRegExp: RegExp = /\/\/vignette(\d|-poz)?\.wikia/;
 	private static domainRegExp: RegExp = /(wikia-dev.com|wikia.nocookie.net)/;
 	private static legacyPathRegExp: RegExp = /(wikia-dev.com|wikia.nocookie.net)\/__cb[\d]+\/.*$/;
+	private static onlyUUIDRegExp: RegExp = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
 
 	public static mode: any = {
 		fixedAspectRatio: 'fixed-aspect-ratio',
@@ -89,6 +90,8 @@ class Vignette {
 		if (this.isLegacyUrl(url)) {
 			urlParameters = this.getParametersFromLegacyUrl(url);
 			url = this.createThumbnailUrl(urlParameters, options);
+		} else if(this.isUUIDOnlyUrl(url)) {
+			url = this.createUUIDBasedThumbnailUrl(url, options);
 		} else if (this.isThumbnailerUrl(url)) {
 			// Accept Vignette URL in order to convert thumbnail to a different mode
 			url = this.updateThumbnailUrl(url, options);
@@ -144,6 +147,19 @@ class Vignette {
 	private static isThumbnailerUrl(url = ''): boolean {
 		return this.imagePathRegExp.test(url);
 	}
+
+	/**
+	 * Checks if url points to new Vignette
+	 *
+	 * @private
+	 *
+	 * @param {String} url
+	 *
+	 * @return {Boolean}
+	 */
+	private static isUUIDOnlyUrl(url = ''): boolean {
+		return this.onlyUUIDRegExp.test(url);
+	};
 
 	/**
 	 * Checks if url points to legacy image URL
@@ -271,6 +287,34 @@ class Vignette {
 
 		return url.join('/') + '?' + query.join('&');
 	}
+
+	/**
+	 * Constructs complete thumbnailer url for UUID based links
+	 *
+	 * @private
+	 *
+	 * @param {string} baseUrl
+	 * @param {object} options
+	 *
+	 * @return {String}
+	 */
+	private static createUUIDBasedThumbnailUrl(
+		baseUrl: string,
+		options: ThumbnailOptions
+	): string {
+		var query = [];
+		var url = [baseUrl];
+
+		if (options) {
+			if (options.hasOwnProperty('mode')) {
+				url.push(this.getModeParameters(options));
+			}
+			if (options.hasOwnProperty('frame')) {
+				query.push('frame=' + ~~options.frame);
+			}
+		}
+		return url.join('/') + (query.length > 0 ? '?' : '') + query.join('&');
+	};
 
 	/**
 	 * Updates a Vignette URL with the given options. May be used to strip all options

--- a/tests/vignette.js
+++ b/tests/vignette.js
@@ -430,6 +430,16 @@ QUnit.test('Thumbnailer creates thumb URL for new UUID based URLs', function () 
 			},
 			expectedOutput: 'https://vignette-poz.wikia-dev.com/c8a832d4-7be6-4748-be94-ed09876547b5' +
 			'/zoom-crop/width/150/height/260'
+		},
+		{
+			url: 'https://vignette-poz.wikia-dev.com/C8A832D4-7BE6-4748-BE94-ED09876547B5',
+			options: {
+				mode: Vignette.mode.zoomCrop,
+				width: 150,
+				height: 260
+			},
+			expectedOutput: 'https://vignette-poz.wikia-dev.com/C8A832D4-7BE6-4748-BE94-ED09876547B5' +
+			'/zoom-crop/width/150/height/260'
 		}
 	];
 	testCases.forEach(function (testCase) {

--- a/tests/vignette.js
+++ b/tests/vignette.js
@@ -408,3 +408,34 @@ QUnit.test('Thumbnailer creates thumb URL for domains with prefixes', function (
 		);
 	});
 });
+
+QUnit.test('Thumbnailer creates thumb URL for new UUID based URLs', function () {
+	var testCases = [
+		{
+			url: 'https://vignette-poz.wikia-dev.com/c8a832d4-7be6-4748-be94-ed09876547b5/',
+			options: {
+				mode: Vignette.mode.topCrop,
+				width: 300,
+				height: 300
+			},
+			expectedOutput: 'https://vignette-poz.wikia-dev.com/c8a832d4-7be6-4748-be94-ed09876547b5' +
+			'/top-crop/width/300/height/300'
+		},
+		{
+			url: 'https://vignette-poz.wikia-dev.com/c8a832d4-7be6-4748-be94-ed09876547b5',
+			options: {
+				mode: Vignette.mode.zoomCrop,
+				width: 150,
+				height: 260
+			},
+			expectedOutput: 'https://vignette-poz.wikia-dev.com/c8a832d4-7be6-4748-be94-ed09876547b5' +
+			'/zoom-crop/width/150/height/260'
+		}
+	];
+	testCases.forEach(function (testCase) {
+		equal(
+			Vignette.getThumbURL(testCase.url, testCase.options),
+			testCase.expectedOutput
+		);
+	});
+});


### PR DESCRIPTION
New, UUID-based vignette URLs are no longer working with this library. (https://vignette-poz.wikia-dev.com/c8a832d4-7be6-4748-be94-ed09876547b5). I think this piece of code fixes that problem.

It check whether there's standard UUID in link, if there is, It just appends link with options in query format. Tests included.

@rogatty 
