### PR TITLE
Changed regex, added tests

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "vignette",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "main": [
     "/dist/vignette.amd.js",
     "/dist/vignette.cjs.js",

--- a/dist/vignette.amd.js
+++ b/dist/vignette.amd.js
@@ -221,10 +221,8 @@ define(["require", "exports"], function (require, exports) {
          */
         Vignette.createUUIDBasedThumbnailUrl = function (baseUrl, options) {
             var query = [];
-            //If last char is '/' then remove it
-            if (baseUrl.charAt(baseUrl.length - 1) === '/') {
-                baseUrl = baseUrl.substring(0, baseUrl.length - 1);
-            }
+            // Remove everything after UUID
+            baseUrl = baseUrl.split('/').splice(0, 4).join('/');
             var url = [baseUrl];
             if (options) {
                 if (options.hasOwnProperty('mode')) {
@@ -292,7 +290,7 @@ define(["require", "exports"], function (require, exports) {
         Vignette.imagePathRegExp = /\/\/vignette(\d|-poz)?\.wikia/;
         Vignette.domainRegExp = /(wikia-dev.com|wikia.nocookie.net)/;
         Vignette.legacyPathRegExp = /(wikia-dev.com|wikia.nocookie.net)\/__cb[\d]+\/.*$/;
-        Vignette.onlyUUIDRegExp = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}(|\/)$/i;
+        Vignette.onlyUUIDRegExp = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}(|\/)/i;
         Vignette.mode = {
             fixedAspectRatio: 'fixed-aspect-ratio',
             fixedAspectRatioDown: 'fixed-aspect-ratio-down',

--- a/dist/vignette.amd.js
+++ b/dist/vignette.amd.js
@@ -292,7 +292,7 @@ define(["require", "exports"], function (require, exports) {
         Vignette.imagePathRegExp = /\/\/vignette(\d|-poz)?\.wikia/;
         Vignette.domainRegExp = /(wikia-dev.com|wikia.nocookie.net)/;
         Vignette.legacyPathRegExp = /(wikia-dev.com|wikia.nocookie.net)\/__cb[\d]+\/.*$/;
-        Vignette.onlyUUIDRegExp = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/i;
+        Vignette.onlyUUIDRegExp = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}(|\/)$/i;
         Vignette.mode = {
             fixedAspectRatio: 'fixed-aspect-ratio',
             fixedAspectRatioDown: 'fixed-aspect-ratio-down',

--- a/dist/vignette.cjs.js
+++ b/dist/vignette.cjs.js
@@ -220,10 +220,8 @@ var Vignette = (function () {
      */
     Vignette.createUUIDBasedThumbnailUrl = function (baseUrl, options) {
         var query = [];
-        //If last char is '/' then remove it
-        if (baseUrl.charAt(baseUrl.length - 1) === '/') {
-            baseUrl = baseUrl.substring(0, baseUrl.length - 1);
-        }
+        // Remove everything after UUID
+        baseUrl = baseUrl.split('/').splice(0, 4).join('/');
         var url = [baseUrl];
         if (options) {
             if (options.hasOwnProperty('mode')) {
@@ -291,7 +289,7 @@ var Vignette = (function () {
     Vignette.imagePathRegExp = /\/\/vignette(\d|-poz)?\.wikia/;
     Vignette.domainRegExp = /(wikia-dev.com|wikia.nocookie.net)/;
     Vignette.legacyPathRegExp = /(wikia-dev.com|wikia.nocookie.net)\/__cb[\d]+\/.*$/;
-    Vignette.onlyUUIDRegExp = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}(|\/)$/i;
+    Vignette.onlyUUIDRegExp = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}(|\/)/i;
     Vignette.mode = {
         fixedAspectRatio: 'fixed-aspect-ratio',
         fixedAspectRatioDown: 'fixed-aspect-ratio-down',

--- a/dist/vignette.cjs.js
+++ b/dist/vignette.cjs.js
@@ -291,7 +291,7 @@ var Vignette = (function () {
     Vignette.imagePathRegExp = /\/\/vignette(\d|-poz)?\.wikia/;
     Vignette.domainRegExp = /(wikia-dev.com|wikia.nocookie.net)/;
     Vignette.legacyPathRegExp = /(wikia-dev.com|wikia.nocookie.net)\/__cb[\d]+\/.*$/;
-    Vignette.onlyUUIDRegExp = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/i;
+    Vignette.onlyUUIDRegExp = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}(|\/)$/i;
     Vignette.mode = {
         fixedAspectRatio: 'fixed-aspect-ratio',
         fixedAspectRatioDown: 'fixed-aspect-ratio-down',

--- a/dist/vignette.js
+++ b/dist/vignette.js
@@ -220,10 +220,8 @@ var Vignette = (function () {
      */
     Vignette.createUUIDBasedThumbnailUrl = function (baseUrl, options) {
         var query = [];
-        //If last char is '/' then remove it
-        if (baseUrl.charAt(baseUrl.length - 1) === '/') {
-            baseUrl = baseUrl.substring(0, baseUrl.length - 1);
-        }
+        // Remove everything after UUID
+        baseUrl = baseUrl.split('/').splice(0, 4).join('/');
         var url = [baseUrl];
         if (options) {
             if (options.hasOwnProperty('mode')) {
@@ -291,7 +289,7 @@ var Vignette = (function () {
     Vignette.imagePathRegExp = /\/\/vignette(\d|-poz)?\.wikia/;
     Vignette.domainRegExp = /(wikia-dev.com|wikia.nocookie.net)/;
     Vignette.legacyPathRegExp = /(wikia-dev.com|wikia.nocookie.net)\/__cb[\d]+\/.*$/;
-    Vignette.onlyUUIDRegExp = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}(|\/)$/i;
+    Vignette.onlyUUIDRegExp = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}(|\/)/i;
     Vignette.mode = {
         fixedAspectRatio: 'fixed-aspect-ratio',
         fixedAspectRatioDown: 'fixed-aspect-ratio-down',

--- a/dist/vignette.js
+++ b/dist/vignette.js
@@ -291,7 +291,7 @@ var Vignette = (function () {
     Vignette.imagePathRegExp = /\/\/vignette(\d|-poz)?\.wikia/;
     Vignette.domainRegExp = /(wikia-dev.com|wikia.nocookie.net)/;
     Vignette.legacyPathRegExp = /(wikia-dev.com|wikia.nocookie.net)\/__cb[\d]+\/.*$/;
-    Vignette.onlyUUIDRegExp = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/i;
+    Vignette.onlyUUIDRegExp = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}(|\/)$/i;
     Vignette.mode = {
         fixedAspectRatio: 'fixed-aspect-ratio',
         fixedAspectRatioDown: 'fixed-aspect-ratio-down',

--- a/src/vignette.ts
+++ b/src/vignette.ts
@@ -26,7 +26,7 @@ class Vignette {
 	private static imagePathRegExp: RegExp = /\/\/vignette(\d|-poz)?\.wikia/;
 	private static domainRegExp: RegExp = /(wikia-dev.com|wikia.nocookie.net)/;
 	private static legacyPathRegExp: RegExp = /(wikia-dev.com|wikia.nocookie.net)\/__cb[\d]+\/.*$/;
-	private static onlyUUIDRegExp: RegExp = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/i;
+	private static onlyUUIDRegExp: RegExp = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}(|\/)$/i;
 
 	public static mode: any = {
 		fixedAspectRatio: 'fixed-aspect-ratio',

--- a/src/vignette.ts
+++ b/src/vignette.ts
@@ -26,7 +26,7 @@ class Vignette {
 	private static imagePathRegExp: RegExp = /\/\/vignette(\d|-poz)?\.wikia/;
 	private static domainRegExp: RegExp = /(wikia-dev.com|wikia.nocookie.net)/;
 	private static legacyPathRegExp: RegExp = /(wikia-dev.com|wikia.nocookie.net)\/__cb[\d]+\/.*$/;
-	private static onlyUUIDRegExp: RegExp = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}(|\/)$/i;
+	private static onlyUUIDRegExp: RegExp = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}(|\/)/i;
 
 	public static mode: any = {
 		fixedAspectRatio: 'fixed-aspect-ratio',
@@ -304,10 +304,8 @@ class Vignette {
 	): string {
 		var query = [];
 
-		//If last char is '/' then remove it
-		if(baseUrl.charAt(baseUrl.length - 1) === '/') {
-			baseUrl = baseUrl.substring(0, baseUrl.length - 1);
-		}
+		// Remove everything after UUID
+		baseUrl = baseUrl.split('/').splice(0,4).join('/');
 
 		var url = [baseUrl];
 

--- a/tests/vignette.js
+++ b/tests/vignette.js
@@ -449,3 +449,44 @@ QUnit.test('Thumbnailer creates thumb URL for new UUID based URLs', function () 
 		);
 	});
 });
+
+QUnit.test('Thumbnailer recognizes vignette URLs vs static.wikia.nocookie.net/ Urls with suffix', function () {
+	var testCases = [
+		{
+			url: 'https://vignette-poz.wikia-dev.com/c8a832d4-7be6-4748-be94-ed09876547b5/',
+			options: {
+				mode: Vignette.mode.topCrop,
+				width: 300,
+				height: 300
+			},
+			expectedOutput: 'https://vignette-poz.wikia-dev.com/c8a832d4-7be6-4748-be94-ed09876547b5' +
+			'/top-crop/width/300/height/300'
+		},
+		{
+			url: 'https://vignette-poz.wikia-dev.com/c8a832d4-7be6-4748-be94-ed09876547b5',
+			options: {
+				mode: Vignette.mode.zoomCrop,
+				width: 150,
+				height: 260
+			},
+			expectedOutput: 'https://vignette-poz.wikia-dev.com/c8a832d4-7be6-4748-be94-ed09876547b5' +
+			'/zoom-crop/width/150/height/260'
+		},
+		{
+			url: 'https://static.wikia.nocookie.net/6f2431a7-19de-494c-91d0-391536b44377/fixed-aspect-ratio/width/100/height/100',
+			options: {
+				mode: Vignette.mode.scaleToWidth,
+				width: 100,
+				height: 100
+			},
+			expectedOutput: 'https://static.wikia.nocookie.net/6f2431a7-19de-494c-91d0-391536b44377' +
+			'/fixed-aspect-ratio/width/100/height/100'
+		}
+	];
+	testCases.forEach(function (testCase) {
+		equal(
+			Vignette.getThumbURL(testCase.url, testCase.options),
+			testCase.expectedOutput
+		);
+	});
+});

--- a/tests/vignette.js
+++ b/tests/vignette.js
@@ -473,14 +473,14 @@ QUnit.test('Thumbnailer recognizes vignette URLs vs static.wikia.nocookie.net/ U
 			'/zoom-crop/width/150/height/260'
 		},
 		{
-			url: 'https://static.wikia.nocookie.net/6f2431a7-19de-494c-91d0-391536b44377/fixed-aspect-ratio/width/100/height/100',
+			url: 'https://static.wikia.nocookie.net/6f2431a7-19de-494c-91d0-391536b44377/fixed-aspect-ratio/width/128/height/128',
 			options: {
 				mode: Vignette.mode.scaleToWidth,
-				width: 100,
-				height: 100
+				width: 256,
+				height: 512
 			},
 			expectedOutput: 'https://static.wikia.nocookie.net/6f2431a7-19de-494c-91d0-391536b44377' +
-			'/fixed-aspect-ratio/width/100/height/100'
+			'/scale-to-width/width/256'
 		}
 	];
 	testCases.forEach(function (testCase) {


### PR DESCRIPTION
Some URLs UUID based, for instance from static.nocookie.wikia were categorized as 'new' vignette urls. This regex change should solve that problem.

Example: http://static.wikia.nocookie.net/6c70a28f-1626-48ff-9178-48d5d12b759c/scale-to-width-down/100/fixed-aspect-ratio/width/100/height/100