### PR TITLE
Allow package to be used as node module

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "vignette",
   "version": "2.1.1",
   "description": "Client-side interface for Vignette thumbnailer",
+  "main": "dist/vignette.cjs",
   "repository": {
     "type": "git",
     "url": "git://github.com/Wikia/vignette-js.git"


### PR DESCRIPTION
When importing package as node module you have to define which file is main file of the package.

In this PR we defined commonJS version that is compatible with node modules.