### PR TITLE
Fix malformed URLs without revision suffix

### DIFF
--- a/dist/vignette.amd.js
+++ b/dist/vignette.amd.js
@@ -160,7 +160,8 @@ define(["require", "exports"], function (require, exports) {
          * @return {object}
          */
         Vignette.getParametersFromLegacyUrl = function (url) {
-            var segments = url.split('/'), result = {};
+            var segments = url.split('/');
+            var result = {};
             // Remove protocol
             segments.splice(0, 2);
             result.domain = this.getBaseDomain(segments.shift());
@@ -244,7 +245,20 @@ define(["require", "exports"], function (require, exports) {
          * @returns {String}
          */
         Vignette.updateThumbnailUrl = function (currentUrl, options) {
-            var newUrl = currentUrl.substring(0, (currentUrl.indexOf('revision/latest') + 15)), queryIndex = currentUrl.indexOf('?'), queryString = '';
+            var queryIndex = currentUrl.indexOf('?');
+            var revisionSuffixIndex = currentUrl.indexOf('revision/latest');
+            var lastBaseUrlCharIndex = currentUrl.length;
+            if (revisionSuffixIndex > -1) {
+                lastBaseUrlCharIndex = revisionSuffixIndex + 15;
+            }
+            else if (queryIndex > -1) {
+                lastBaseUrlCharIndex = queryIndex;
+            }
+            var newUrl = currentUrl.substring(0, lastBaseUrlCharIndex);
+            if (revisionSuffixIndex === -1) {
+                newUrl += '/revision/latest';
+            }
+            var queryString = '';
             if (queryIndex > -1) {
                 queryString = currentUrl.substring(queryIndex);
             }

--- a/dist/vignette.cjs.js
+++ b/dist/vignette.cjs.js
@@ -159,7 +159,8 @@ var Vignette = (function () {
      * @return {object}
      */
     Vignette.getParametersFromLegacyUrl = function (url) {
-        var segments = url.split('/'), result = {};
+        var segments = url.split('/');
+        var result = {};
         // Remove protocol
         segments.splice(0, 2);
         result.domain = this.getBaseDomain(segments.shift());
@@ -243,7 +244,20 @@ var Vignette = (function () {
      * @returns {String}
      */
     Vignette.updateThumbnailUrl = function (currentUrl, options) {
-        var newUrl = currentUrl.substring(0, (currentUrl.indexOf('revision/latest') + 15)), queryIndex = currentUrl.indexOf('?'), queryString = '';
+        var queryIndex = currentUrl.indexOf('?');
+        var revisionSuffixIndex = currentUrl.indexOf('revision/latest');
+        var lastBaseUrlCharIndex = currentUrl.length;
+        if (revisionSuffixIndex > -1) {
+            lastBaseUrlCharIndex = revisionSuffixIndex + 15;
+        }
+        else if (queryIndex > -1) {
+            lastBaseUrlCharIndex = queryIndex;
+        }
+        var newUrl = currentUrl.substring(0, lastBaseUrlCharIndex);
+        if (revisionSuffixIndex === -1) {
+            newUrl += '/revision/latest';
+        }
+        var queryString = '';
         if (queryIndex > -1) {
             queryString = currentUrl.substring(queryIndex);
         }

--- a/dist/vignette.js
+++ b/dist/vignette.js
@@ -159,7 +159,8 @@ var Vignette = (function () {
      * @return {object}
      */
     Vignette.getParametersFromLegacyUrl = function (url) {
-        var segments = url.split('/'), result = {};
+        var segments = url.split('/');
+        var result = {};
         // Remove protocol
         segments.splice(0, 2);
         result.domain = this.getBaseDomain(segments.shift());
@@ -243,7 +244,20 @@ var Vignette = (function () {
      * @returns {String}
      */
     Vignette.updateThumbnailUrl = function (currentUrl, options) {
-        var newUrl = currentUrl.substring(0, (currentUrl.indexOf('revision/latest') + 15)), queryIndex = currentUrl.indexOf('?'), queryString = '';
+        var queryIndex = currentUrl.indexOf('?');
+        var revisionSuffixIndex = currentUrl.indexOf('revision/latest');
+        var lastBaseUrlCharIndex = currentUrl.length;
+        if (revisionSuffixIndex > -1) {
+            lastBaseUrlCharIndex = revisionSuffixIndex + 15;
+        }
+        else if (queryIndex > -1) {
+            lastBaseUrlCharIndex = queryIndex;
+        }
+        var newUrl = currentUrl.substring(0, lastBaseUrlCharIndex);
+        if (revisionSuffixIndex === -1) {
+            newUrl += '/revision/latest';
+        }
+        var queryString = '';
         if (queryIndex > -1) {
             queryString = currentUrl.substring(queryIndex);
         }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "git://github.com/Wikia/vignette-js.git"
   },
   "scripts": {
-    "test": "node tests/qunit-runner.js"
+    "test": "gulp && node tests/qunit-runner.js"
   },
   "license": "MIT",
   "devDependencies": {

--- a/src/vignette.ts
+++ b/src/vignette.ts
@@ -65,7 +65,7 @@ class Vignette {
 		url: string,
 		options: ThumbnailOptions
 		): string {
-		var urlParameters: ImageUrlParameters;
+		let urlParameters: ImageUrlParameters;
 
 		if (options) {
 			this.verifyThumbnailOptions(options);
@@ -207,8 +207,8 @@ class Vignette {
 	 * @return {object}
 	 */
 	private static getParametersFromLegacyUrl(url: string): ImageUrlParameters {
-		var segments = url.split('/'),
-			result: any = {};
+		let segments = url.split('/');
+		const result: any = {};
 
 		// Remove protocol
 		segments.splice(0, 2);
@@ -241,7 +241,7 @@ class Vignette {
 		urlParameters: ImageUrlParameters,
 		options: ThumbnailOptions
 		): string {
-		var url	= [
+		const url = [
 				'https://vignette.' + urlParameters.domain,
 				urlParameters.wikiaBucket,
 				urlParameters.imagePath,
@@ -282,12 +282,12 @@ class Vignette {
 		baseUrl: string,
 		options: ThumbnailOptions
 	): string {
-		var query = [];
+		const query = [];
 
 		// Remove everything after UUID
 		baseUrl = baseUrl.split('/').splice(0,4).join('/');
 
-		var url = [baseUrl];
+		const url = [baseUrl];
 
 		if (options) {
 			if (options.hasOwnProperty('mode')) {
@@ -312,10 +312,22 @@ class Vignette {
 	 * @returns {String}
 	 */
 	private static updateThumbnailUrl(currentUrl: string, options: ThumbnailOptions): string {
-		var newUrl = currentUrl.substring(0, (currentUrl.indexOf('revision/latest') + 15)),
-			queryIndex = currentUrl.indexOf('?'),
-			queryString = '';
+		const queryIndex = currentUrl.indexOf('?');
+		const revisionSuffixIndex = currentUrl.indexOf('revision/latest');
 
+		let lastBaseUrlCharIndex = currentUrl.length;
+		if (revisionSuffixIndex > -1) {
+			lastBaseUrlCharIndex = revisionSuffixIndex + 15;
+		} else if (queryIndex > -1) {
+			lastBaseUrlCharIndex = queryIndex;
+		}
+
+		let newUrl = currentUrl.substring(0, lastBaseUrlCharIndex);
+		if (revisionSuffixIndex === -1) {
+			newUrl += '/revision/latest';
+		}
+
+		let queryString = '';
 		if (queryIndex > -1) {
 			queryString = currentUrl.substring(queryIndex);
 		}
@@ -341,7 +353,7 @@ class Vignette {
 	 * @returns {String}
 	 */
 	private static getModeParameters(options: ThumbnailOptions): string {
-		var modeParameters = [
+		const modeParameters = [
 			options.mode
 		];
 

--- a/tests/vignette.js
+++ b/tests/vignette.js
@@ -115,6 +115,14 @@ QUnit.test('Vignette creates thumbnail URL', function () {
 			// With no options passed, should return a Vignette URL to a full-size image
 			expectedOutput: 'https://vignette.wikia-dev.com/thelastofus/images/9/99/Robert.png/revision/latest' +
 				'?cb=20130614225714'
+		},
+		{
+			url: 'https://vignette.wikia.nocookie.net/muppet/images/d/d9/Jim-and-jim.jpg',
+			expectedOutput: 'https://vignette.wikia.nocookie.net/muppet/images/d/d9/Jim-and-jim.jpg/revision/latest'
+		},
+		{
+			url: 'https://vignette.wikia.nocookie.net/muppet/images/d/d9/Jim-and-jim.jpg?cb=123',
+			expectedOutput: 'https://vignette.wikia.nocookie.net/muppet/images/d/d9/Jim-and-jim.jpg/revision/latest?cb=123'
 		}
 	];
 


### PR DESCRIPTION
Stop breaking on URLs like https://vignette.wikia.nocookie.net/messaging/images/4/46/Avatar3.jpg which are stored in the user-attribute service.